### PR TITLE
Allow order specification in each_directory

### DIFF
--- a/lib/fudge/tasks/each_directory.rb
+++ b/lib/fudge/tasks/each_directory.rb
@@ -15,7 +15,10 @@ module Fudge
       end
 
       def run(options={})
-        Dir[@pattern].select { |path| File.directory? path }.each do |dir|
+        # Allow either a string (usually "*") or an array of strings with directories
+        redir = @pattern.kind_of?(String) ? Dir[@pattern] : Dir[*@pattern]
+
+        redir.select { |path| File.directory? path }.each do |dir|
           next if exclude && exclude.include?(dir)
 
           Dir.chdir dir do

--- a/spec/lib/fudge/tasks/each_directory_spec.rb
+++ b/spec/lib/fudge/tasks/each_directory_spec.rb
@@ -37,5 +37,21 @@ describe Fudge::Tasks::EachDirectory do
 
       task.pwds.should == dirs
     end
+
+    it "should allow explicit specification of directories through an array" do
+      ed2 = described_class.new ["spec/lib","spec/support"]
+      ed2.tasks << task
+      ed2.run
+      task.pwds.should == dirs.sort
+    end
+
+    it "should respect the order of the directories as specified" do
+      ed2 = described_class.new ["spec/support","spec/lib"]
+      ed2.tasks << task
+      ed2.run
+      task.pwds.should_not == dirs.sort
+      task.pwds.sort.should == dirs.sort
+    end
+
   end
 end


### PR DESCRIPTION
We need to be able to specify a list of directories and give the order in which to build them.

We have build order dependencies in [sageone_es](http://github.com/Sage/sageone_es) which require "sageone_host" to test before "sagespain_extensions". Should work since they're in alphabetical order, right? Well, wrong. Fudge is grabbing those directories in reverse order (based on the order handed over by the operating system).
