### PR TITLE
Building fudge while using fudge requires fudge as a gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in fudge.gemspec
 gemspec
+
+# fudge needed as gem to build fudge with fudge
+group :test do
+  gem "fudge", :path => "."
+end


### PR DESCRIPTION
... otherwise Bundler can't use it in a pure Rbenv setup on Jenkins.

/var/lib/jenkins/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/bundler-1.2.1/lib/bundler/rubygems_integration.rb:147:in `block in replace_gem': fudge is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
    from /var/lib/jenkins/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/bin/fudge:22:in`<main>'
