### PR TITLE
Bump version number to 0.1.0

### DIFF
--- a/lib/fudge/version.rb
+++ b/lib/fudge/version.rb
@@ -1,4 +1,4 @@
 module Fudge
   # Define gem version
-  VERSION = "0.0.5"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
Since we have new functionality (flog and flay) bumping the version number.
