### PR TITLE
Fixed output encoding issues

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+# v0.2.2
+* Made the default encoding Encoding::UTF_8 to solve issues with regex match of the console output
+
 # v0.2.1
 * Updated json dependency from ~>1.7.7 to ~>1.8.0
 

--- a/lib/fudge.rb
+++ b/lib/fudge.rb
@@ -1,6 +1,14 @@
 require 'rainbow'
 require 'active_support/all'
 
+#TODO: I think it will be safe to remove this once we start using Ruby 2.0
+#This will fix errors: invalid byte sequence in US-ASCII (ArgumentError) when UTF-8 chars get
+#in the console output.
+if RUBY_VERSION =~ /1.9/
+  Encoding.default_external = Encoding::UTF_8
+  Encoding.default_internal = Encoding::UTF_8
+end
+
 # Fudge implementation
 module Fudge
   autoload :Build, 'fudge/build'

--- a/lib/fudge/version.rb
+++ b/lib/fudge/version.rb
@@ -1,4 +1,4 @@
 module Fudge
   # Define gem version
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
If the console outputs UTF-8 chars, the match method for regular expressions would raise the error: invalid byte sequence in US-ASCII (ArgumentError).
This will fix that.
