### PR TITLE
Fixing grep in FileFinder to avoid conflicts with colors specified in GREP_OPTIONS

### DIFF
--- a/lib/fudge/file_finder.rb
+++ b/lib/fudge/file_finder.rb
@@ -21,14 +21,14 @@ module Fudge
     def find_filters
       filters = []
       filters << 'find .'
-      filters << "grep -e '\\.rb$'"
+      filters << "grep --color=never -e '\\.rb$'"
       filters << exclude_filter
       filters.compact
     end
 
     def exclude_filter
       if (pattern = options[:exclude])
-        "grep -v -E '#{pattern}'"
+        "grep --color=never -v -E '#{pattern}'"
       end
     end
   end

--- a/spec/lib/fudge/tasks/flay_spec.rb
+++ b/spec/lib/fudge/tasks/flay_spec.rb
@@ -20,7 +20,7 @@ EOF
 
   describe :run do
     it "runs flay on the codebase" do
-      subject.should run_command "flay --diff `find . | grep -e '\\.rb$'`"
+      subject.should run_command "flay --diff `find . | grep --color=never -e '\\.rb$'`"
     end
 
     context 'with :exclude => pattern' do
@@ -28,7 +28,7 @@ EOF
 
       # Test doesn't check result :(
       it "filters out the pattern" do
-        cmd = "flay --diff `find . | grep -e '\\.rb$' | grep -v -E 'spec/'`"
+        cmd = "flay --diff `find . | grep --color=never -e '\\.rb$' | grep --color=never -v -E 'spec/'`"
         subject.should run_command cmd
       end
     end

--- a/spec/lib/fudge/tasks/flog_spec.rb
+++ b/spec/lib/fudge/tasks/flog_spec.rb
@@ -47,7 +47,7 @@ EOF
 
   describe :run do
     it "runs flog on the codebase" do
-      subject.should run_command "flog `find . | grep -e '\\.rb$'`"
+      subject.should run_command "flog `find . | grep --color=never -e '\\.rb$'`"
     end
 
     context 'with :exclude => pattern' do
@@ -55,7 +55,7 @@ EOF
 
       # Test doesn't check result :(
       it "filters out the pattern" do
-        with_pattern = "flog `find . | grep -e '\\.rb$' | grep -v -E 'spec/'`"
+        with_pattern = "flog `find . | grep --color=never -e '\\.rb$' | grep --color=never -v -E 'spec/'`"
         subject.should run_command with_pattern
       end
     end
@@ -64,7 +64,7 @@ EOF
       subject {described_class.new :methods => true}
 
       it "runs with methods only flag" do
-        with_pattern = "flog -m `find . | grep -e '\\.rb$'`"
+        with_pattern = "flog -m `find . | grep --color=never -e '\\.rb$'`"
         subject.should run_command with_pattern
       end
     end


### PR DESCRIPTION
Fixes issues when you have GREP_OPTIONS for grep. Such as:

`GREP_OPTIONS="--color=always";export GREP_OPTIONS`

When you run flog or flay you will get the following error:

`Unknown file type: rb, defaulting to ruby`
`No such file or directory - ./app/controllers/accountants_core/accountants_controller.rb`
