### PR TITLE
Fix argument handling in Fudge::Tasks::Task

### DIFF
--- a/lib/fudge/tasks/task.rb
+++ b/lib/fudge/tasks/task.rb
@@ -14,13 +14,13 @@ module Fudge
 
       def initialize(*args)
         @args = args.dup
-        @options = args.extract_options!
+        @options = @args.extract_options!
 
-        options.each do |k,v|
+        @options.each do |k,v|
           send("#{k}=", v) if respond_to?("#{k}=")
         end
 
-        args
+        @args
       end
     end
   end

--- a/spec/lib/fudge/tasks/task_spec.rb
+++ b/spec/lib/fudge/tasks/task_spec.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
 
 class MyTask < Fudge::Tasks::Task
-  attr_accessor :blabla
+  attr_accessor :cod
+
+  attr_accessor :_methods_missing
+  def method_missing(method, *args)
+    (@_methods_missing ||= []).push(method)
+  end
 end
 
 class TestNamespace
@@ -11,10 +16,51 @@ end
 
 describe Fudge::Tasks::Task do
   describe :initialize do
-    it "should accepts options and set them" do
-      task = MyTask.new :blabla => 'foo'
+    context "given arguments" do
+      it "accepts and stores the arguments" do
+        task = MyTask.new :foo, :bar, :baz
+        expect(task.args).to match_array [:foo, :bar, :baz]
+      end
+    end
 
-      task.blabla.should == 'foo'
+    context "given options" do
+      let (:task) { MyTask.new :cod => 'fanglers' }
+
+      it "accepts and sets the options" do
+        expect(task.cod).to eq 'fanglers'
+      end
+
+      it "accepts and stores the options" do
+        expect(task.options).to eq({ cod: 'fanglers' })
+      end
+
+      context "including an option that is not supported" do
+        let (:task) { MyTask.new :cod => 'fanglers', :foo => 'bar' }
+
+        it "ignores the unsupported options" do
+          expect(task._methods_missing).to be_nil
+        end
+
+        it "stores all provided options" do
+          expect(task.options).to eq({ cod: 'fanglers', foo: 'bar' })
+        end
+      end
+    end
+
+    context "given arguments and options" do
+      let (:task) { MyTask.new :foo, :bar, :cod => 'fanglers' }
+
+      it "stores the arguments separately from the options" do
+        expect(task.args).to match_array [:foo, :bar]
+      end
+
+      it "applies the options" do
+        expect(task.cod).to eq 'fanglers'
+      end
+
+      it "stores the options separately from the arguments" do
+        expect(task.options).to eq({ cod: 'fanglers' })
+      end
     end
   end
 


### PR DESCRIPTION
Task does not handle its arguments correctly.  It copies and stores
incoming arguments, and then extracts the options from the arguments
and stores those too.

However, it extracts the options from the incoming arguments, not the
copy it has made.  A method should not alter its parameters, as they
may be used elsewhere.  Also, the stored arguments still retain the
options hash, which is probably unintended.

This change extracts the options from the stored copy of the
arguments.

Fixes #84.
