### PR TITLE
Reduce flog complexity score

### DIFF
--- a/lib/fudge/output_checker.rb
+++ b/lib/fudge/output_checker.rb
@@ -52,4 +52,3 @@ class Fudge::OutputChecker
   end
 
 end
-

--- a/lib/fudge/runner.rb
+++ b/lib/fudge/runner.rb
@@ -19,9 +19,7 @@ module Fudge
 
     def output_start(which, output)
       which_build = String.new(which)
-
-      output.puts "Running build ".foreground(:cyan) +
-        which_build.bright.foreground(:yellow)
+      output.puts %Q(#{'Running build'.foreground(:cyan)} #{which_build.bright.foreground(:yellow)})
     end
 
     def run(which, options)

--- a/lib/fudge/tasks/cane.rb
+++ b/lib/fudge/tasks/cane.rb
@@ -16,11 +16,7 @@ module Fudge
       end
 
       def tty_options
-        args = []
-        args << doc_options
-        args << style_options
-        args << style_width_options
-        args.compact
+        args = [doc_options, style_options, style_width_options].compact
       end
 
       def doc_options

--- a/lib/fudge/tasks/composite_task.rb
+++ b/lib/fudge/tasks/composite_task.rb
@@ -47,11 +47,8 @@ module Fudge
       end
 
       def output_message(t, output)
-          message = []
-          message << running_coloured
-          message << task_name_coloured(t)
-          message << args_coloured(t)
-          output.puts message.join(' ')
+          message = "#{running_coloured} #{task_name_coloured(t)} #{args_coloured(t)}"
+          output.puts message
       end
 
       def running_coloured

--- a/lib/fudge/tasks/each_directory.rb
+++ b/lib/fudge/tasks/each_directory.rb
@@ -13,11 +13,11 @@ module Fudge
 
       def run(options={})
         output = options[:output] || $stdout
-        directories.each do |dir|
-          next if skip_directory?(dir)
-          WithDirectory.new(dir, output).inside do
-            return false unless super
-          end
+        directories.all? do |dir|
+          skip_directory?(dir) ||
+            WithDirectory.new(dir, output).inside do
+              super
+            end
         end
       end
 

--- a/lib/fudge/tasks/flog.rb
+++ b/lib/fudge/tasks/flog.rb
@@ -66,19 +66,9 @@ module Fudge
       end
 
       def extract_scores(matches)
-        average = max = total = 0
-        extract_lines(matches).each do |value, key|
-          case key
-            when 'flog total'
-              total = value.to_f
-            when 'flog/method average'
-              average = value.to_f
-            else
-              max = value.to_f unless value.nil?
-              break
-          end
-        end
-        [average, max, total]
+        values = extract_lines(matches).take(3).map(&:first)
+        total, average, max = values.map(&:to_f)
+        [average, (max || 0.0), total]
       end
 
       def extract_lines(matches)

--- a/lib/fudge/with_directory.rb
+++ b/lib/fudge/with_directory.rb
@@ -18,10 +18,7 @@ class Fudge::WithDirectory
   private
 
   def output_message
-    message = ""
-    message << "--> In directory".foreground(:cyan)
-    message << " #{dir}:".foreground(:cyan).bright
-
+    message = %Q(#{'--> In directory'.foreground(:cyan)} #{"#{dir}:".foreground(:cyan).bright})
     output.puts message
   end
 end


### PR DESCRIPTION
A number of small tweaks to reduce the flog complexity score, without
affecting functionality.

Before:
   504.4: flog total
     4.2: flog/method average

After:
   489.9: flog total
     4.1: flog/method average
