### PR TITLE
Support ActiveSupport 4.1.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+# v0.4.1
+* Fix problem with YAML in activesupport 4.1.0 [#92](https://github.com/Sage/fudge/pull/92)
+
 # v0.4.0
 * Reworked output processing [#89](https://github.com/Sage/fudge/pull/89)
 * Removed rainbow dependency [#90](https://github.com/Sage/fudge/pull/90)

--- a/lib/fudge/tasks/composite_task.rb
+++ b/lib/fudge/tasks/composite_task.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 module Fudge
   module Tasks
     # Allow for tasks to be combined
@@ -37,7 +39,7 @@ module Fudge
       def fudge_settings
         fpath = "#{Dir.pwd}/fudge_settings.yml"
         if File.exist?(fpath)
-          return YAML.load_file(fpath)
+          return ::YAML.load_file(fpath)
         end
         {}
       end

--- a/lib/fudge/version.rb
+++ b/lib/fudge/version.rb
@@ -1,4 +1,4 @@
 module Fudge
   # Define gem version
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
Upon migration to ActiveSupport 4.1.0 fudge will fail when reading fudge_settings.  This fixes it.
