### PR TITLE
Remove useless message in absence of callbacks

### DIFF
--- a/lib/fudge/build.rb
+++ b/lib/fudge/build.rb
@@ -25,8 +25,6 @@ module Fudge
       success = super
       if callbacks
         return false unless run_callbacks(success)
-      else
-        message "Skipping callbacks..."
       end
       report_time(start_time, time)
 

--- a/spec/lib/fudge/build_spec.rb
+++ b/spec/lib/fudge/build_spec.rb
@@ -12,8 +12,7 @@ describe Fudge::Build do
       it "prints messages to the formatter instead of default" do
         subject.run :formatter => formatter
 
-        expect(stdout.string).not_to be_empty
-        expect(stdout.string).to include "Skipping callbacks..."
+        expect(stdout.string).to be_empty
       end
 
       context "when there are callback hooks" do


### PR DESCRIPTION
if there aren't any callbacks then we're not skipping anything.  This reduces noise by eliminating a useless line of output in basically every single build everywhere as callbacks aren't used very much.