### PR TITLE
Add support for brakeman 4.5.0 output

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
+# v0.6.4
+* Add support for brakeman 4.5.0 output
+
 # v0.6.3
 * Add cucumber coverage check
-* Rubocop improvements 
+* Rubocop improvements
 
 # v0.6.2
 * Add cucumber support.

--- a/lib/fudge/tasks/brakeman.rb
+++ b/lib/fudge/tasks/brakeman.rb
@@ -27,7 +27,7 @@ module Fudge
       end
 
       def check_regex
-        /\| Security Warnings \| (?<score>\d+) /
+        /\|?\s?Security Warnings\:?\s?\|?\s?(?<score>\d+)/
       end
 
       def brakeman_checker(matches)

--- a/lib/fudge/version.rb
+++ b/lib/fudge/version.rb
@@ -1,4 +1,4 @@
 module Fudge
   # Define gem version
-  VERSION = '0.6.3'
+  VERSION = '0.6.4'
 end

--- a/spec/lib/fudge/tasks/brakeman_spec.rb
+++ b/spec/lib/fudge/tasks/brakeman_spec.rb
@@ -39,6 +39,16 @@ Model Warnings:
 EOF
   end
 
+  let(:output_good_new) do
+    <<-EOF
+Controllers: 3
+Models: 0
+Templates: 30
+Errors: 0
+Security Warnings: 0
+EOF
+  end
+
   describe '#run' do
     it 'runs brakeman on the codebase' do
       expect(subject).to run_command 'brakeman '
@@ -46,6 +56,7 @@ EOF
 
     it { is_expected.not_to succeed_with_output output_bad }
     it { is_expected.to succeed_with_output output_good }
+    it { is_expected.to succeed_with_output output_good_new }
 
     context 'when :max score is supplied' do
       it 'fails when score is higher than max' do


### PR DESCRIPTION
Brakeman 4.5.0 was breaking fudge analysis as the output from Brakeman had changed:

Old Output format:

`
| Scanned/Reported  | Total |

-----------+-------+

| Controllers       | 17    |

| Models            | 25    |

| Templates         | 99    |

| Errors            | 0     |

| Security Warnings | 0 (0) |

+-------------------+-------+`

New Output format
`== Overview ==

Controllers: 3

Models: 0

Templates: 30

Errors: 0

Security Warnings: 0`

Updated brakeman regex to allow both formats to be recognised