### PR TITLE
Test UTF-8 chars

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,22 @@
-guard 'rspec', version: 2 do
-  watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb')  { 'spec' }
+options = {
+  cmd: "clear && bundle exec rspec spec/ --no-profile --order defined --fail-fast",
+  all_after_pass: false,
+  all_on_start: false,
+  failed_mode: :focus
+}
+
+guard :rspec, options do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+  watch(%r{^lib/(.+)\.rb}) { rspec.spec_dir }
 end

--- a/spec/lib/fudge/output_checker_spec.rb
+++ b/spec/lib/fudge/output_checker_spec.rb
@@ -7,6 +7,13 @@ describe Fudge::OutputChecker do
   describe '#check' do
     subject { described_class.new(/foo/, formatter) }
 
+    context 'handing UTF-8 chars' do
+      it 'send a mismatch message to the output io' do
+        subject.check('Ẅȟö Ḽềƚ Ŧḩȅ ḊŐǵṥ ƠǗẗ')
+        expect(output_io.string).to include "Output didn't match (?-mix:foo)."
+      end
+    end
+
     context 'when the output does not match the check' do
       it 'send a mismatch message to the output io' do
         subject.check('bar')

--- a/spec/lib/fudge/tasks/rspec_spec.rb
+++ b/spec/lib/fudge/tasks/rspec_spec.rb
@@ -31,6 +31,7 @@ describe Fudge::Tasks::Rspec do
     it { is_expected.not_to succeed_with_output '98.99999%) covered' }
     it { is_expected.not_to succeed_with_output '0.00%) covered' }
     it { is_expected.to succeed_with_output '99.99999%) covered' }
+    fit { is_expected.to succeed_with_output 'Ẅȟö Ḽềƚ Ŧḩȅ ḊŐǵṥ ƠǗẗ 99.99999%) covered' }
     it { is_expected.to succeed_with_output '100.0%) covered' }
     it { is_expected.to succeed_with_output "\n0 examples, 0 failures" }
     it { is_expected.to succeed_with_output "No examples found.\n\n\nFinished in 0.00006 seconds\n\e[32m0 examples, 0 failures\e[0m\n" }


### PR DESCRIPTION
Test UTF-8 chars

For some reason, because a test had this data which was printed in to STDOUT an exception on was raised on fudge when parsing the output through the match method.

But this spec seems to prove that the problem is not here.

```
      {
        user_registration_details: {
          first_name: 'João Ãlbîrquža',
          last_name: 'João-Ãlbîrquža Rolland',
          email: 'joão-ãlbîrquža@email.com'
        }
      }
```

```
bundler: failed to load command: fudge (/usr/local/bundle/bin/fudge)
ArgumentError: invalid byte sequence in US-ASCII
/usr/local/bundle/bundler/gems/fudge-2a22b68f5ea9/lib/fudge/output_checker.rb:50:in `match'
```